### PR TITLE
reset sharedData when executing resetAll

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,9 +168,10 @@ _.resetAll = function(callback) {
 
 	that.resetFlag = true;
 
-	that.options.preProcess(that, function() {
+	that.options.preProcess(that, function(sharedData) {
 		var workers = [];
 
+		that.sharedData = sharedData;
 		for (var id in cluster.workers) {
 			var worker = cluster.workers[id];
 


### PR DESCRIPTION
In the current version, hard reset doesn't make any changes to sharedData which includes curriculum data.

Thus function call to preProcess(that, function() { ... }) should be like preProcess(that, function(sharedData) { that.sharedData = sharedData; ... }).
